### PR TITLE
Security: Implement Emergency Admin Suspension for DAO Governance (#15)

### DIFF
--- a/src/AccessController.sol
+++ b/src/AccessController.sol
@@ -1,25 +1,49 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "./identity.sol";
+import "./SovereignIdentityRegistry.sol";
 
 contract AccessController {
 
     SovereignIdentityRegistry public identityRegistry;
+    address public securityCouncil;
 
     mapping(address => bool) private admins;
+    mapping(address => bool) private suspendedAdmins;
 
     event AdminAdded(address indexed user);
+    event AdminSuspended(address indexed user);
+    event AdminReinstated(address indexed user);
 
-    constructor(address registryAddress) {
+    constructor(address registryAddress, address _securityCouncil) {
         require(registryAddress != address(0), "Invalid registry address");
+        require(_securityCouncil != address(0), "Invalid security council");
+        
         identityRegistry = SovereignIdentityRegistry(registryAddress);
+        securityCouncil = _securityCouncil;
         admins[msg.sender] = true;
     }
 
     modifier onlyAdmin() {
         require(admins[msg.sender], "Not admin");
+        require(!suspendedAdmins[msg.sender], "Admin suspended");
         _;
+    }
+
+    modifier onlySecurityCouncil() {
+        require(msg.sender == securityCouncil, "Not security council");
+        _;
+    }
+
+    function suspendAdmin(address user) external onlySecurityCouncil {
+        require(admins[user], "Not an admin");
+        suspendedAdmins[user] = true;
+        emit AdminSuspended(user);
+    }
+
+    function reinstateAdmin(address user) external onlySecurityCouncil {
+        suspendedAdmins[user] = false;
+        emit AdminReinstated(user);
     }
 
     modifier onlyVerifiedUser() {

--- a/src/CoreLogic.sol
+++ b/src/CoreLogic.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "./AccessControl.sol";
+import "./AccessController.sol";
 
 contract CoreLogic is AccessController {
 
@@ -9,8 +9,8 @@ contract CoreLogic is AccessController {
 
     event DataUpdated(uint256 indexed id, string value);
 
-    constructor(address registryAddress) 
-        AccessController(registryAddress) 
+    constructor(address registryAddress, address securityCouncil) 
+        AccessController(registryAddress, securityCouncil) 
     {}
 
     function setData(uint256 id, string calldata value) 

--- a/test/Issue35Validation.t.sol
+++ b/test/Issue35Validation.t.sol
@@ -13,13 +13,14 @@ contract Issue35ValidationTest is Test {
 
     address public admin = address(0x1);
     address public user = address(0x2);
+    address public securityCouncil = address(0x3);
 
     function setUp() public {
         registry = new SovereignIdentityRegistry();
         vm.prank(admin);
-        controller = new AccessController(address(registry));
+        controller = new AccessController(address(registry), securityCouncil);
         vm.prank(admin);
-        logic = new CoreLogic(address(registry));
+        logic = new CoreLogic(address(registry), securityCouncil);
     }
 
     // --- SovereignIdentityRegistry Tests ---
@@ -44,7 +45,38 @@ contract Issue35ValidationTest is Test {
 
     function test_Controller_Fail_ZeroRegistry() public {
         vm.expectRevert("Invalid registry address");
-        new AccessController(address(0));
+        new AccessController(address(0), securityCouncil);
+    }
+
+    function test_Controller_Fail_ZeroSecurityCouncil() public {
+        vm.expectRevert("Invalid security council");
+        new AccessController(address(registry), address(0));
+    }
+
+    function test_Controller_Suspension() public {
+        // Suspend the admin
+        vm.prank(securityCouncil);
+        controller.suspendAdmin(admin);
+
+        // Admin should now fail onlyAdmin check
+        vm.prank(admin);
+        vm.expectRevert("Admin suspended");
+        controller.addAdmin(user);
+
+        // Reinstate
+        vm.prank(securityCouncil);
+        controller.reinstateAdmin(admin);
+
+        // Should work now
+        vm.prank(admin);
+        controller.addAdmin(user);
+        assertTrue(controller.isAdmin(user));
+    }
+
+    function test_Controller_Fail_UnauthorizedSuspend() public {
+        vm.prank(admin);
+        vm.expectRevert("Not security council");
+        controller.suspendAdmin(admin);
     }
 
     function test_Controller_Fail_AddZeroAdmin() public {


### PR DESCRIPTION
## Overview
This PR addresses **Issue #15** by introducing an emergency suspension layer to the DAO's access control system. This bridges the gap between decentralized governance (slow) and security response (fast).

## Changes
- **Security Council Role**: Added a dedicated `securityCouncil` address to `AccessController.sol`.
- **Emergency Suspension**: Implemented `suspendAdmin` and `reinstateAdmin` functions.
  - *Fast Path*: The Security Council can immediately block a compromised admin's access.
  - *Slow Path*: The DAO can take its time with a formal vote for permanent revocation.
- **Modifier Enforcement**: Updated `onlyAdmin` to verify the suspension status on every call.
- **Automated Testing**: Added comprehensive tests in `Issue35Validation.t.sol` covering:
  - Immediate suspension of privileges.
  - Reinstatement of privileges.
  - Unauthorized suspension attempts.
  - Zero-address protection for the Security Council.

## Verification
- Ran `forge test --match-path test/Issue35Validation.t.sol`
- **Results**: 11 passed, 0 failed.

Fixes #15