### PR TITLE
fix: prevent admin self-lockout and owner removal in AuthManager

### DIFF
--- a/contracts/core/AuthManager.sol
+++ b/contracts/core/AuthManager.sol
@@ -3,6 +3,8 @@
 
  contract AuthManager {
      mapping(address => bool) private admins;
+     address public immutable owner;
+     uint256 private adminCount;
 
      event AdminAdded(address indexed user);
      event AdminRemoved(address indexed user);
@@ -13,17 +15,26 @@
      }
 
      constructor() {
+         owner = msg.sender;
          admins[msg.sender] = true;
+         adminCount = 1;
      }
 
      function addAdmin(address user) external onlyAdmin {
          require(user != address(0), "Invalid address");
+         require(!admins[user], "Already an admin");
          admins[user] = true;
+         adminCount++;
          emit AdminAdded(user);
      }
 
      function removeAdmin(address user) external onlyAdmin {
+         require(user != address(0), "Invalid address");
+         require(admins[user], "Not an admin");
+         require(user != owner, "Cannot remove owner");
+         require(adminCount > 1, "Cannot remove last admin");
          admins[user] = false;
+         adminCount--;
          emit AdminRemoved(user);
      }
 


### PR DESCRIPTION
- Add immutable owner to protect deployer from removal
- Track adminCount to block removal of last admin
- Guard removeAdmin against removing owner or non-existent admin
- Guard addAdmin against duplicate registration to keep count accurate