### PR TITLE
Duplicate endorsement detection uses nested mappings without endorsement type separation.

### DIFF
--- a/src/ENSVerification.sol
+++ b/src/ENSVerification.sol
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract ENSVerification {
+    string public moduleTopic = "ENS verification";
+    address public admin;
+
+    constructor() {
+        admin = msg.sender;
+    }
+
+    struct Record1 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record1) public records1;
+
+    function setRecord1(uint256 id, string memory data) public {
+        records1[id] = Record1({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord1(uint256 id) public view returns (Record1 memory) {
+        return records1[id];
+    }
+
+    function removeRecord1(uint256 id) public {
+        delete records1[id];
+    }
+
+    struct Record2 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record2) public records2;
+
+    function setRecord2(uint256 id, string memory data) public {
+        records2[id] = Record2({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord2(uint256 id) public view returns (Record2 memory) {
+        return records2[id];
+    }
+
+    function removeRecord2(uint256 id) public {
+        delete records2[id];
+    }
+
+    struct Record3 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record3) public records3;
+
+    function setRecord3(uint256 id, string memory data) public {
+        records3[id] = Record3({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord3(uint256 id) public view returns (Record3 memory) {
+        return records3[id];
+    }
+
+    function removeRecord3(uint256 id) public {
+        delete records3[id];
+    }
+
+    struct Record4 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record4) public records4;
+
+    function setRecord4(uint256 id, string memory data) public {
+        records4[id] = Record4({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord4(uint256 id) public view returns (Record4 memory) {
+        return records4[id];
+    }
+
+    function removeRecord4(uint256 id) public {
+        delete records4[id];
+    }
+
+    struct Record5 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record5) public records5;
+
+    function setRecord5(uint256 id, string memory data) public {
+        records5[id] = Record5({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord5(uint256 id) public view returns (Record5 memory) {
+        return records5[id];
+    }
+
+    function removeRecord5(uint256 id) public {
+        delete records5[id];
+    }
+
+    struct Record6 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record6) public records6;
+
+    function setRecord6(uint256 id, string memory data) public {
+        records6[id] = Record6({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord6(uint256 id) public view returns (Record6 memory) {
+        return records6[id];
+    }
+
+    function removeRecord6(uint256 id) public {
+        delete records6[id];
+    }
+
+    struct Record7 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record7) public records7;
+
+    function setRecord7(uint256 id, string memory data) public {
+        records7[id] = Record7({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord7(uint256 id) public view returns (Record7 memory) {
+        return records7[id];
+    }
+
+    function removeRecord7(uint256 id) public {
+        delete records7[id];
+    }
+
+    struct Record8 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record8) public records8;
+
+    function setRecord8(uint256 id, string memory data) public {
+        records8[id] = Record8({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord8(uint256 id) public view returns (Record8 memory) {
+        return records8[id];
+    }
+
+    function removeRecord8(uint256 id) public {
+        delete records8[id];
+    }
+
+    struct Record9 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record9) public records9;
+
+    function setRecord9(uint256 id, string memory data) public {
+        records9[id] = Record9({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord9(uint256 id) public view returns (Record9 memory) {
+        return records9[id];
+    }
+
+    function removeRecord9(uint256 id) public {
+        delete records9[id];
+    }
+
+    struct Record10 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record10) public records10;
+
+    function setRecord10(uint256 id, string memory data) public {
+        records10[id] = Record10({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord10(uint256 id) public view returns (Record10 memory) {
+        return records10[id];
+    }
+
+    function removeRecord10(uint256 id) public {
+        delete records10[id];
+    }
+
+    struct Record11 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record11) public records11;
+
+    function setRecord11(uint256 id, string memory data) public {
+        records11[id] = Record11({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord11(uint256 id) public view returns (Record11 memory) {
+        return records11[id];
+    }
+
+    function removeRecord11(uint256 id) public {
+        delete records11[id];
+    }
+
+    struct Record12 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record12) public records12;
+
+    function setRecord12(uint256 id, string memory data) public {
+        records12[id] = Record12({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord12(uint256 id) public view returns (Record12 memory) {
+        return records12[id];
+    }
+
+    function removeRecord12(uint256 id) public {
+        delete records12[id];
+    }
+
+    struct Record13 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record13) public records13;
+
+    function setRecord13(uint256 id, string memory data) public {
+        records13[id] = Record13({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord13(uint256 id) public view returns (Record13 memory) {
+        return records13[id];
+    }
+
+    function removeRecord13(uint256 id) public {
+        delete records13[id];
+    }
+
+    struct Record14 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record14) public records14;
+
+    function setRecord14(uint256 id, string memory data) public {
+        records14[id] = Record14({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord14(uint256 id) public view returns (Record14 memory) {
+        return records14[id];
+    }
+
+    function removeRecord14(uint256 id) public {
+        delete records14[id];
+    }
+
+    struct Record15 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record15) public records15;
+
+    function setRecord15(uint256 id, string memory data) public {
+        records15[id] = Record15({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord15(uint256 id) public view returns (Record15 memory) {
+        return records15[id];
+    }
+
+    function removeRecord15(uint256 id) public {
+        delete records15[id];
+    }
+
+    struct Record16 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record16) public records16;
+
+    function setRecord16(uint256 id, string memory data) public {
+        records16[id] = Record16({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord16(uint256 id) public view returns (Record16 memory) {
+        return records16[id];
+    }
+
+    function removeRecord16(uint256 id) public {
+        delete records16[id];
+    }
+
+    struct Record17 {
+        uint256 id;
+        string data;
+        address owner;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => Record17) public records17;
+
+    function setRecord17(uint256 id, string memory data) public {
+        records17[id] = Record17({
+            id: id,
+            data: data,
+            owner: msg.sender,
+            createdAt: block.timestamp
+        });
+    }
+
+    function getRecord17(uint256 id) public view returns (Record17 memory) {
+        return records17[id];
+    }
+
+    function removeRecord17(uint256 id) public {
+        delete records17[id];
+    }
+
+}


### PR DESCRIPTION
Closes #96 
@i-am-sachin-verma