### PR TITLE
fix struct semicolons and add openzeppelin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/contracts/Security/InstitutionalAttestationFramework.sol
+++ b/contracts/Security/InstitutionalAttestationFramework.sol
@@ -55,7 +55,7 @@ contract InstitutionalAttestationFramework is AccessControl {
         bool active;
 
         uint256 reputation;
-    };
+    }
 
 
 
@@ -80,7 +80,7 @@ contract InstitutionalAttestationFramework is AccessControl {
         uint256 expiry;
 
         CredentialStatus status;
-    };
+    }
 
 
 
@@ -95,7 +95,7 @@ contract InstitutionalAttestationFramework is AccessControl {
         bool verified;
 
         uint256 issuedCredentials;
-    };
+    }
 
 
 

--- a/contracts/Security/Lock.sol
+++ b/contracts/Security/Lock.sol
@@ -61,7 +61,7 @@ contract DynamicMetadataStorage is AccessControl {
         bool enabled;
 
         uint32 maxKeys;
-    };
+    }
 
 
 

--- a/contracts/Security/Sec.sol
+++ b/contracts/Security/Sec.sol
@@ -65,7 +65,7 @@ contract SecureRecoveryManager {
         string reason;
 
         uint256 timestamp;
-    };
+    }
 
 
 

--- a/contracts/Security/VersionedEndorsementManager.sol
+++ b/contracts/Security/VersionedEndorsementManager.sol
@@ -58,7 +58,7 @@ contract VersionedEndorsementManager {
         uint256 revokedCount;
 
         uint256 expiredCount;
-    };
+    }
 
 
 

--- a/contracts/Security/dev.sol
+++ b/contracts/Security/dev.sol
@@ -43,7 +43,7 @@ contract DecentralizedTrustScoring {
         uint256 activityScore;
 
         uint256 updatedAt;
-    };
+    }
 
 
 

--- a/contracts/assist/CircularOnchain.sol
+++ b/contracts/assist/CircularOnchain.sol
@@ -14,7 +14,7 @@ contract CircularEndorsementDetector {
         uint256 timestamp;
 
         bool active;
-    };
+    }
 
 
 

--- a/contracts/assist/Graph.sol
+++ b/contracts/assist/Graph.sol
@@ -14,7 +14,7 @@ contract IndexedEventIdentitySystem {
         uint256 reputation;
 
         bool active;
-    };
+    }
 
 
 
@@ -29,7 +29,7 @@ contract IndexedEventIdentitySystem {
         uint256 createdAt;
 
         bool active;
-    };
+    }
 
 
 

--- a/contracts/assist/emergency.sol
+++ b/contracts/assist/emergency.sol
@@ -34,7 +34,7 @@ contract EmergencyPausableIdentitySystem is
         uint64 createdAt;
 
         bool active;
-    };
+    }
 
 
 
@@ -47,7 +47,7 @@ contract EmergencyPausableIdentitySystem is
         uint64 timestamp;
 
         bool active;
-    };
+    }
 
 
 

--- a/contracts/assist/instCred.sol
+++ b/contracts/assist/instCred.sol
@@ -54,7 +54,7 @@ contract InstitutionalCredentialRevocation is AccessControl {
         uint64 expiry;
 
         CredentialStatus status;
-    };
+    }
 
 
 
@@ -67,7 +67,7 @@ contract InstitutionalCredentialRevocation is AccessControl {
         uint256 issuedCredentials;
 
         uint256 revokedCredentials;
-    };
+    }
 
 
 

--- a/contracts/assist/internal.sol
+++ b/contracts/assist/internal.sol
@@ -63,7 +63,7 @@ contract HierarchicalInstitutionRoles is AccessControl {
         uint64 createdAt;
 
         bool active;
-    };
+    }
 
 
 
@@ -84,7 +84,7 @@ contract HierarchicalInstitutionRoles is AccessControl {
         uint64 expiry;
 
         bool revoked;
-    };
+    }
 
 
 

--- a/contracts/assist/protection.sol
+++ b/contracts/assist/protection.sol
@@ -32,7 +32,7 @@ contract GaslessEndorsementManager {
         uint256 timestamp;
 
         bool active;
-    };
+    }
 
 
 

--- a/contracts/core/AdavnceControl.sol
+++ b/contracts/core/AdavnceControl.sol
@@ -53,7 +53,7 @@ contract AdvancedIdentityRegistry is ERC721, AccessControl {
         bool rejected;
 
         uint256 submittedAt;
-    };
+    }
 
 
 
@@ -64,7 +64,7 @@ contract AdvancedIdentityRegistry is ERC721, AccessControl {
         string actionType;
 
         address actor;
-    };
+    }
 
 
 

--- a/contracts/core/recovery.sol
+++ b/contracts/core/recovery.sol
@@ -89,7 +89,7 @@ contract SignatureBackupRecovery
         uint256 timestamp;
 
         bool resolved;
-    };
+    }
 
 
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,9 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+remappings = [
+    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
+    "forge-std/=lib/forge-std/src/"
+]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
closes #180 
structs in solidity don't take a semicolon after the closing brace — removed the stray ones across 14 files. also added openzeppelin-contracts as a submodule and dropped the remapping in `foundry.toml` so the imports actually resolve.

