### PR TITLE
fix: replace transfer() with low-level call in CrowdfundingPlatform

### DIFF
--- a/contracts/core/CrowdfundingPlatform.sol
+++ b/contracts/core/CrowdfundingPlatform.sol
@@ -81,9 +81,18 @@ contract CrowdfundingPlatform {
         require(c.raised >= c.goal, "Goal not met");
         require(!c.claimed, "Already claimed");
 
+        // Checks-Effects-Interactions: update state before the external call to
+        // prevent reentrancy. Zero out raised so a re-entrant claim gets 0 value.
         c.claimed = true;
+        uint256 amount = c.raised;
+        c.raised = 0;
 
-        payable(c.creator).transfer(c.raised);
+        // Use low-level call instead of transfer() to support contract-based
+        // creators (smart contract wallets, Gnosis Safe, multi-sig proxies).
+        // transfer() forwards only 2300 gas, which is insufficient for any
+        // contract with a non-trivial receive/fallback, permanently locking funds.
+        (bool success, ) = payable(c.creator).call{value: amount}("");
+        require(success, "Transfer failed");
 
         emit Claimed(id);
     }
@@ -103,7 +112,10 @@ contract CrowdfundingPlatform {
 
         contributions[id][msg.sender] = 0;
 
-        payable(msg.sender).transfer(amount);
+        // Use low-level call for the same reason as claim(): transfer() forwards
+        // only 2300 gas and will revert for contract-based contributors.
+        (bool success, ) = payable(msg.sender).call{value: amount}("");
+        require(success, "Refund failed");
 
         emit Refunded(id, msg.sender);
     }


### PR DESCRIPTION
## Summary

Closes #479

`CrowdfundingPlatform.sol` used `payable(c.creator).transfer(c.raised)` in `claim()` and `payable(msg.sender).transfer(amount)` in `refund()`. `transfer()` forwards only **2300 gas**, which is less than the minimum required to execute the `receive()`/`fallback()` of any non-trivial smart contract wallet (Gnosis Safe costs >6000 gas for its receiver). Any campaign creator or contributor using a contract wallet would find every call to `claim()` or `refund()` reverting permanently, with no recovery path for the locked ETH.

## Changes

`contracts/core/CrowdfundingPlatform.sol`:

**`claim()`**:
- Cache `c.raised` in a local `amount` variable
- Zero out `c.raised` before the external call (checks-effects-interactions prevents reentrancy)
- Send with `(bool success, ) = payable(c.creator).call{value: amount}(""); require(success, "Transfer failed");`

**`refund()`**:
- Contribution is already zeroed before the call (existing CEI pattern preserved)
- Switch to `.call` for the same reason

## Test plan

- [ ] EOA campaign creator can still call `claim()` and receive ETH
- [ ] Contract wallet creator (e.g., mock contract with a 6000-gas receiver) can call `claim()` and receive ETH
- [ ] `refund()` works for both EOA and contract-based contributors
- [ ] Re-entrant `claim()` call receives 0 value (raised is zeroed before the external call)

Could you please add the appropriate NSoC labels when you get a chance? Thank you!