### PR TITLE
fix: guard revokeEndorsement against double-decrement on EXPIRED endorsements

### DIFF
--- a/contracts/Security/VersionedEndorsementManager.sol
+++ b/contracts/Security/VersionedEndorsementManager.sol
@@ -227,9 +227,17 @@ contract VersionedEndorsementManager {
             "Unauthorized"
         );
 
+        // Guard against double-decrement: if the endorsement has already been
+        // transitioned to EXPIRED or REVOKED the active counters were already
+        // decremented by markExpired() or a prior revokeEndorsement() call.
+        // Checking status (not just the revoked flag) closes the desync window
+        // where markExpired() sets status=EXPIRED but leaves revoked=false,
+        // which would allow revokeEndorsement() to pass the old !revoked guard
+        // and decrement activeCredentialCount/activeCount a second time.
         require(
-            !endorsement.revoked,
-            "Already revoked"
+            endorsement.status
+                == EndorsementStatus.ACTIVE,
+            "Endorsement is not active"
         );
 
 


### PR DESCRIPTION
## Summary

Closes #480

`VersionedEndorsementManager.sol` maintains two overlapping lifecycle fields: `bool revoked` and `EndorsementStatus status`. `markExpired()` transitions `status` to `EXPIRED` but never sets `revoked = true`. `revokeEndorsement()` guarded against double-revocation with `require(!endorsement.revoked)` but not against the `EXPIRED` state. This allowed `revokeEndorsement()` to run on an already-EXPIRED endorsement, decrementing `activeCredentialCount` and `tokenStats.activeCount` a second time and permanently corrupting on-chain credential accounting.

## Root cause

| Function | Sets `revoked` | Sets `status` | Decrements active counters |
|---|---|---|---|
| `markExpired()` | No | `EXPIRED` | Yes |
| `revokeEndorsement()` | Yes | `REVOKED` | Yes |

After `markExpired()` runs, `revoked` is still `false`. The `!endorsement.revoked` guard passes, and `revokeEndorsement()` decrements the counters again.

## Fix

Replace the `!revoked` flag check with `status == ACTIVE`. This is the single authoritative guard that covers all terminal states (EXPIRED and REVOKED). The `revoked` flag and `revokedAt` fields are still set for historical lookup.

## Test plan

- [ ] `revokeEndorsement()` on an ACTIVE endorsement succeeds and decrements counters exactly once
- [ ] `revokeEndorsement()` on an already-REVOKED endorsement reverts with "Endorsement is not active"
- [ ] Calling `markExpired()` then `revokeEndorsement()` on the same endorsement reverts (no double-decrement)
- [ ] `getCredentialCount` returns correct values after any combination of expire/revoke operations

Could you please add the appropriate NSoC labels when you get a chance? Thank you!