### PR TITLE
fix: replace fixed-size buffer with two-pass sizing in getSecondDegreeConnections

### DIFF
--- a/contracts/Security/TrustGraphManager.sol
+++ b/contracts/Security/TrustGraphManager.sol
@@ -355,25 +355,29 @@ contract TrustGraphManager {
         uint256[] memory firstLevel =
             forwardAdjacency[tokenId];
 
+        uint256 firstLen = firstLevel.length;
 
+        // Pass 1: count the exact number of second-degree entries so the result
+        // array can be allocated to the right size. The previous approach used
+        // firstLevel.length * 10 as an upper bound, which is an arbitrary heuristic
+        // with no contract invariant to back it. Any first-degree neighbor with
+        // more than 10 outgoing edges causes an out-of-bounds Panic(0x32) revert,
+        // permanently DoS-ing this view for the affected tokenId.
+        uint256 totalCount;
 
-        uint256 maxSize =
-            firstLevel.length * 10;
+        for (uint256 i = 0; i < firstLen; i++) {
+            totalCount += forwardAdjacency[firstLevel[i]].length;
+        }
 
+        uint256[] memory result =
+            new uint256[](totalCount);
 
+        uint256 index;
 
-        uint256[] memory temp =
-            new uint256[](maxSize);
-
-
-
-        uint256 counter;
-
-
-
+        // Pass 2: fill the result array.
         for (
             uint256 i = 0;
-            i < firstLevel.length;
+            i < firstLen;
             i++
         ) {
 
@@ -385,37 +389,20 @@ contract TrustGraphManager {
             uint256[] memory secondLevel =
                 forwardAdjacency[neighbor];
 
-
+            uint256 secondLen = secondLevel.length;
 
             for (
                 uint256 j = 0;
-                j < secondLevel.length;
+                j < secondLen;
                 j++
             ) {
 
-                temp[counter] =
+                result[index] =
                     secondLevel[j];
 
-                counter++;
+                index++;
             }
         }
-
-
-
-        uint256[] memory result =
-            new uint256[](counter);
-
-
-
-        for (
-            uint256 i = 0;
-            i < counter;
-            i++
-        ) {
-            result[i] = temp[i];
-        }
-
-
 
         return result;
     }


### PR DESCRIPTION
## Summary

Closes #481

`getSecondDegreeConnections()` allocated a temporary buffer as `firstLevel.length * 10`. This assumes no first-degree neighbor of `tokenId` has more than 10 outgoing connections. `createConnection()` enforces no such limit. The moment any first-degree neighbor accumulates 11+ outgoing edges, every call to `getSecondDegreeConnections()` for nodes connected to that neighbor reverts with `Panic(0x32)` (array out-of-bounds write), permanently DoS-ing graph traversal for those nodes.

## Root cause

```solidity
uint256 maxSize = firstLevel.length * 10;   // no invariant backs this
uint256[] memory temp = new uint256[](maxSize);
...
temp[counter] = secondLevel[j];   // counter can exceed maxSize -> Panic
counter++;
```

## Fix

Two-pass approach:

**Pass 1** -- sum `forwardAdjacency[neighbor].length` for every first-degree neighbor to compute the exact total count.

**Pass 2** -- allocate `result[]` to that exact count and fill it.

No temporary oversized buffer, no arbitrary multiplier, no out-of-bounds risk. Public ABI and return semantics are unchanged.

## Test plan

- [ ] `getSecondDegreeConnections(A)` works correctly when neighbors have 0, 1, or 10 outgoing connections
- [ ] Works correctly when a neighbor has 11 or more outgoing connections (previously panicked)
- [ ] Returns empty array when `tokenId` has no outgoing connections
- [ ] Returns empty array when all first-degree neighbors have no outgoing connections

Could you please add the appropriate NSoC labels when you get a chance? Thank you!