### PR TITLE
fix(CrowdfundingPlatform): add validation for campaign goal and duration

### DIFF
--- a/contracts/core/CrowdfundingPlatform.sol
+++ b/contracts/core/CrowdfundingPlatform.sol
@@ -42,6 +42,8 @@ contract CrowdfundingPlatform {
     // ============================================================
 
     function createCampaign(uint256 goal, uint256 duration) external {
+        require(goal > 0, "Campaign goal must be greater than zero");
+        require(duration > 0, "Campaign duration must be greater than zero");
         campaignCount++;
 
         campaigns[campaignCount] = Campaign({


### PR DESCRIPTION
Prevents creation of campaigns with zero goal, which would be immediately claimable without funding.

## Problem
The createCampaign function accepted a goal of zero, creating a logical error where:
- A campaign with goal=0 would always be >= raised amount
- Creators could immediately claim funds even with zero contributions
- No legitimate use case for zero-goal campaigns

## Solution
Added validation to prevent zero goals and durations:
- require(goal > 0, "Campaign goal must be greater than zero")
- require(duration > 0, "Campaign duration must be greater than zero")

## Impact
- Prevents fund claiming without contributions
- Ensures all campaigns have meaningful funding targets
- Maintains campaign integrity

Fixes #658