### PR TITLE
fix: prevent DoS in batchUpdate with size limits and authorization

### DIFF
--- a/contracts/core/TrustScoreEngine.sol
+++ b/contracts/core/TrustScoreEngine.sol
@@ -17,6 +17,29 @@ contract TrustScoreEngine is TrustScoreLogic {
     // Anti-collusion contract (plug-in)
     address public antiCollusionContract;
 
+    // Owner for access control
+    address public owner;
+
+    // Maximum batch size to prevent DoS via unbounded gas consumption
+    uint256 public constant MAX_BATCH_SIZE = 200;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Only owner can call this function");
+        _;
+    }
+
+    modifier onlyAuthorized() {
+        require(
+            msg.sender == owner || msg.sender == antiCollusionContract,
+            "Only authorized callers can execute this function"
+        );
+        _;
+    }
+
     /**
      * Set external anti-collusion contract
      */
@@ -36,9 +59,16 @@ contract TrustScoreEngine is TrustScoreLogic {
     }
 
     /**
-     * Batch update (gas optimized for multiple identities)
+     * Batch update with bounded array length (gas optimized for multiple identities)
+     * Prevents DoS attacks via unbounded calldata array iteration
      */
-    function batchUpdate(uint256[] calldata tokenIds) external {
+    function batchUpdate(uint256[] calldata tokenIds) external onlyAuthorized {
+        require(tokenIds.length > 0, "Empty batch not allowed");
+        require(
+            tokenIds.length <= MAX_BATCH_SIZE,
+            "Batch size exceeds maximum allowed"
+        );
+
         for (uint256 i = 0; i < tokenIds.length; i++) {
             uint256 score = computeScore(tokenIds[i]);
             identities[tokenIds[i]].reputation = score;


### PR DESCRIPTION
## Summary
Implement MAX_BATCH_SIZE constant and authorization checks to prevent denial-of-service attacks through unbounded batch operations in the batchUpdate function.

## Security Fixes
- Add MAX_BATCH_SIZE = 200 constant to prevent unbounded gas consumption
- Implement onlyAuthorized modifier for access control (owner or antiCollusionContract only)
- Add empty batch validation and batch size boundary checks
- Establish owner pattern for future security controls

## Changes
- Added owner field with constructor initialization
- Defined onlyOwner and onlyAuthorized modifiers
- Updated batchUpdate to enforce size bounds and authorization
- Added require statements for batch validation

## Test Plan
- [ ] Verify batchUpdate rejects empty arrays
- [ ] Verify batchUpdate rejects arrays exceeding MAX_BATCH_SIZE (200)
- [ ] Verify only owner and antiCollusionContract can call batchUpdate
- [ ] Verify authorized calls with valid batch sizes succeed

Closes #659

Signed-off-by: Anshul Jain <anshul23102@iiitd.ac.in>