### PR TITLE
fix: restrict applyPenalty to authorized callers with value validation

### DIFF
--- a/contracts/core/TrustScoreEngine.sol
+++ b/contracts/core/TrustScoreEngine.sol
@@ -17,6 +17,26 @@ contract TrustScoreEngine is TrustScoreLogic {
     // Anti-collusion contract (plug-in)
     address public antiCollusionContract;
 
+    // Owner for access control
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Only owner can call this function");
+        _;
+    }
+
+    modifier onlyAuthorized() {
+        require(
+            msg.sender == owner || msg.sender == antiCollusionContract,
+            "Only authorized callers can execute this function"
+        );
+        _;
+    }
+
     /**
      * Set external anti-collusion contract
      */
@@ -48,9 +68,11 @@ contract TrustScoreEngine is TrustScoreLogic {
     }
 
     /**
-     * Apply manual penalty (from anti-collusion or admin)
+     * Apply manual penalty (restricted to authorized callers)
+     * Prevents arbitrary penalty inflation by unauthorized addresses
      */
-    function applyPenalty(uint256 tokenId, uint256 penalty) external {
+    function applyPenalty(uint256 tokenId, uint256 penalty) external onlyAuthorized {
+        require(penalty > 0, "Penalty must be greater than zero");
         penaltyScore[tokenId] += penalty;
     }
 


### PR DESCRIPTION
## Summary
Add authorization checks and input validation to the applyPenalty function to prevent unauthorized penalty inflation and enforce valid penalty amounts.

## Security Fixes
- Implement onlyAuthorized modifier restricting calls to owner or antiCollusionContract only
- Add positive penalty validation to reject zero-value penalties
- Establish owner pattern for smart contract access control
- Prevent arbitrary penalty manipulation by external actors

## Changes
- Added owner field and constructor initialization
- Defined onlyOwner and onlyAuthorized modifiers
- Updated applyPenalty with authorization check and positive value validation
- Added inline documentation for security constraints

## Test Plan
- [ ] Verify unauthorized callers are rejected
- [ ] Verify zero penalties are rejected
- [ ] Verify owner can apply penalties
- [ ] Verify antiCollusionContract can apply penalties

Closes #656

Signed-off-by: Anshul Jain <anshul23102@iiitd.ac.in>