### PR TITLE
fix: restrict setAntiCollusion to owner only with null address validation

### DIFF
--- a/contracts/core/TrustScoreEngine.sol
+++ b/contracts/core/TrustScoreEngine.sol
@@ -17,10 +17,24 @@ contract TrustScoreEngine is TrustScoreLogic {
     // Anti-collusion contract (plug-in)
     address public antiCollusionContract;
 
+    // Owner for access control
+    address public owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Only owner can call this function");
+        _;
+    }
+
     /**
-     * Set external anti-collusion contract
+     * Set external anti-collusion contract (restricted to owner)
+     * Prevents unauthorized replacement of anti-collusion module
      */
-    function setAntiCollusion(address _contract) external {
+    function setAntiCollusion(address _contract) external onlyOwner {
+        require(_contract != address(0), "Invalid contract address");
         antiCollusionContract = _contract;
     }
 


### PR DESCRIPTION
## Summary
Restrict the setAntiCollusion function to owner-only access and add null address validation to prevent unauthorized replacement of the anti-collusion module.

## Security Fixes
- Implement onlyOwner modifier restricting calls to contract owner only
- Add null address check to prevent setting address(0) as anti-collusion contract
- Establish owner pattern for critical security module configuration
- Prevent unauthorized modification of anti-collusion enforcement mechanism

## Changes
- Added owner field and constructor initialization
- Defined onlyOwner modifier
- Updated setAntiCollusion with owner restriction and address validation
- Added inline documentation for security constraints

## Test Plan
- [ ] Verify non-owner callers are rejected
- [ ] Verify null address (address(0)) is rejected
- [ ] Verify owner can set valid anti-collusion contract
- [ ] Verify anti-collusion contract reference is updated correctly

Closes #655

Signed-off-by: Anshul Jain <anshul23102@iiitd.ac.in>