### PR TITLE
ES Module environment

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
### Description

Fixes #690 

This PR resolves a fatal `ReferenceError` in `vite.config.js` that causes the Vite dev server and build processes to crash. 

Because Vite enforces an ES Module environment by default, CommonJS variables like `__dirname` are undefined. The configuration was attempting to use `__dirname` for path aliasing, resulting in an immediate crash upon execution.

**Changes Made:**
* Imported `fileURLToPath` from the standard Node.js `url` module.
* Derived `__filename` using `import.meta.url`.
* Reconstructed `__dirname` using `path.dirname(__filename)`.
* Kept all existing path aliases and Vite configurations intact so they now resolve perfectly.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing Instructions
1. Pull this branch and navigate to the frontend directory.
2. Run `npm run dev` or `npm run build`.
3. The Vite configuration should successfully parse, and the server/build should start without throwing a Node.js error.